### PR TITLE
Update base16 repo paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # base16_color_scheme
 
-A library to build [base16](https://github.com/chriskempson/base16) colorschemes written in Rust.
+A library to build [base16](https://github.com/tinted-theming/home) colorschemes written in Rust.
 
 It uses [ramhorns](https://docs.rs/ramhorns/latest/ramhorns/index.html)
 as template engine and therefore is fairly fast. \
-(Around 70 ms - 200 ms for a 9 mb template I generated based on <https://github.com/chriskempson/base16-templates-source>.)
+(Around 70 ms - 200 ms for a 9 mb template I generated based on <https://github.com/tinted-theming/base16-schemes>.)
 
 ## Getting Started
 
@@ -38,4 +38,4 @@ template
 Internally the crate works by implementing [`ramhorns`](https://docs.rs/ramhorns/latest/ramhorns/index.html)'s [`Content`](https://docs.rs/ramhorns/0.14.0/ramhorns/trait.Content.html) trait.
 When the rendering process tries to look up a field, the field name gets
 parsed into a [`TemplateField`](https://docs.rs/base16_color_scheme/0.3.1/base16_color_scheme/template/enum.TemplateField.html). If it is a color, this color is fetched
-from the [`Scheme`](https://docs.rs/base16_color_scheme/0.3.1/base16_color_scheme/scheme/struct.Scheme.html) and formatted as specified by <https://github.com/chriskempson/base16/blob/main/builder.md#template-tags>.
+from the [`Scheme`](https://docs.rs/base16_color_scheme/0.3.1/base16_color_scheme/scheme/struct.Scheme.html) and formatted as specified by <https://github.com/tinted-theming/home/blob/main/builder.md#template-variables>.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 //! # base16_color_scheme
 //!
-//! A library to build [base16](https://github.com/tinted-theming/variables) colorschemes written in Rust.
+//! A library to build [base16](https://github.com/tinted-theming/home) colorschemes written in Rust.
 //!
 //! It uses [ramhorns](https://docs.rs/ramhorns/latest/ramhorns/index.html)
 //! as template engine and therefore is fairly fast. \

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,10 @@
 //! # base16_color_scheme
 //!
-//! A library to build [base16](https://github.com/chriskempson/base16) colorschemes written in Rust.
+//! A library to build [base16](https://github.com/tinted-theming/variables) colorschemes written in Rust.
 //!
 //! It uses [ramhorns](https://docs.rs/ramhorns/latest/ramhorns/index.html)
 //! as template engine and therefore is fairly fast. \
-//! (Around 70 ms - 200 ms for a 9 mb template I generated based on <https://github.com/chriskempson/base16-templates-source>.)
+//! (Around 70 ms - 200 ms for a 9 mb template I generated based on <https://github.com/tinted-theming/base16-schemes>.)
 //!
 //! ## Getting Started
 //!
@@ -38,7 +38,7 @@
 //! Internally the crate works by implementing [`ramhorns`]'s [`Content`](ramhorns::Content) trait.
 //! When the rendering process tries to look up a field, the field name gets
 //! parsed into a [`TemplateField`](template::TemplateField). If it is a color, this color is fetched
-//! from the [`Scheme`] and formatted as specified by <https://github.com/chriskempson/base16/blob/main/builder.md#template-tags>.
+//! from the [`Scheme`] and formatted as specified by <https://github.com/tinted-theming/home/blob/main/builder.md#template-variables>.
 
 pub use crate::scheme::Scheme;
 pub use ramhorns::Template;

--- a/src/scheme.rs
+++ b/src/scheme.rs
@@ -55,7 +55,7 @@ mod rgb_color;
 /// Because `scheme-slug` is not created while deserialization it has to be inserted manually.
 /// Either by setting [`Scheme::slug`] manually, or using [`Scheme::create_slug`].
 ///
-/// When serializing Scheme it first serializes [`Scheme::scheme`] and [`Scheme::author`] then ignores [`Scheme::slug`] as per [specification](https://github.com/chriskempson/base16/blob/main/file.md#scheme-files)
+/// When serializing Scheme it first serializes [`Scheme::scheme`] and [`Scheme::author`] then ignores [`Scheme::slug`] as per [specification](https://github.com/tinted-theming/home/blob/main/builder.md#template-repository)
 /// and afterwards serializes all colors contained in [`Scheme::colors`] ordered by the field number.\
 /// (`base00`, `base01`, `base05` etc.)
 #[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
@@ -98,7 +98,7 @@ impl Scheme {
     }
 }
 
-/// create a slug from a scheme name based on the [specification](https://github.com/chriskempson/base16/blob/main/builder.md#template-tags).
+/// create a slug from a scheme name based on the [specification](https://github.com/tinted-theming/home/blob/main/builder.md#template-variables).
 ///
 /// # Example
 ///

--- a/src/scheme/rgb_color/formatter.rs
+++ b/src/scheme/rgb_color/formatter.rs
@@ -5,7 +5,7 @@ use crate::{
 use ramhorns::{encoding::Encoder, Content};
 use std::fmt::{self, Display, Formatter};
 
-/// formatter that formats a color according to the [specification](https://github.com/chriskempson/base16/blob/main/builder.md#template-tags)
+/// formatter that formats a color according to the [specification](https://github.com/tinted-theming/home/blob/main/builder.md#template-variables)
 ///
 /// This formatter contains a color and a specifier in what format this color should be formatted.
 ///

--- a/src/template.rs
+++ b/src/template.rs
@@ -5,7 +5,7 @@ pub mod color_field;
 
 /// type representing a field in the mustache template
 ///
-/// see <https://github.com/chriskempson/base16/blob/main/builder.md#template-tags>
+/// see <https://github.com/tinted-theming/home/main/builder.md#template-variables>
 ///
 /// # Examples
 ///

--- a/src/template/color_field.rs
+++ b/src/template/color_field.rs
@@ -14,7 +14,7 @@ pub use self::format::{hsl::HslFormatter, Dec, Format, Hex, Hsl, Rgb};
 mod format;
 
 /// this represents a field in the template containing a color description defined by the
-/// [specification](https://github.com/chriskempson/base16/blob/main/builder.md#template-tags)
+/// [specification](https://github.com/tinted-themiung/home/blob/main/builder.md#template-variables)
 ///
 /// Note that in contrast to the base16 spec this supports up to 256 colors. \
 /// (exactly what fits into a [`u8`])


### PR DESCRIPTION
Hi @titaniumtraveler, a group of us are working on continuing the work of base16 on [tinted-theming](https://github.com/tinted-theming). Most of us were involved with base16 before we created tinted-theming. It was a bit of a process creating the org, but you can read follow the issues about it here: https://github.com/tinted-theming/home/issues/51

There was a lot of [talk about creating a base16 organization](https://web.archive.org/web/20210124190254/https://github.com/chriskempson/base16/issues/74) dating back to 2016, but ultimately, last year, Chris nuked the repo entirely, so there's no history, issues, etc anymore.

I came across your repo because I'm building [base16-builder-rust](https://github.com/tinted-theming/base16-builder-rust) and also rewriting [base16-shell](https://github.com/tinted-theming/base16-shell) `profile_helper.sh` [functionality in rust](https://github.com/tinted-theming/base16-shell/pull/39).

The links I've replaced in this PR updates to the tinted-theming equivalent paths. The original base16 repos issues have been deleted and history nuked, so any future updates to won't exist there.

We will continue to have builder spec updates, currently working on version `0.11.0`, so some implementations may change slightly in future as things grow. Would you be interested in joining the [tinted-theming](https://github.com/tinted-theming) org and moving the repo there? If you're not interested in that, that's totally fine and maybe we can work closely with each other to update it as the base16 spec evolves if it's needed?